### PR TITLE
Rename various items that referred to nginx-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #PKG := github.com/drud/repo_name
 
 # Docker repo for a push
-DOCKER_REPO ?= drud/nginx-proxy
+DOCKER_REPO ?= drud/ddev-router
 
 # Upstream repo used in the Dockerfile
 UPSTREAM_REPO ?= jwilder/nginx-proxy:0.4.0
@@ -39,8 +39,8 @@ include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_python.mak
 
 test: container
-	@docker stop nginx-proxy-test 2>/dev/null || true
-	@docker rm nginx-proxy-test 2>/dev/null || true
-	docker run -p 1082:80 -v /var/run/docker.sock:/tmp/docker.sock:ro --name nginx-proxy-test -d $(DOCKER_REPO):$(VERSION)
+	@docker stop ddev-router-test 2>/dev/null || true
+	@docker rm ddev-router-test 2>/dev/null || true
+	docker run -p 1082:80 -v /var/run/docker.sock:/tmp/docker.sock:ro --name ddev-router-test -d $(DOCKER_REPO):$(VERSION)
 	sleep 5 && curl -s -I localhost:1082 | grep 503  # Make sure we get a 503 from nginx by default
-	@docker stop nginx-proxy-test 
+	@docker stop ddev-router-test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is based on the [jwilder/nginx-proxy](http;//github.com/jwilder/nginx-proxy) project and contains DRUD specific overrides to the nginx config template. If you are looking for a generalized docker router solution, we recommend you look there.
 
+Previously this project was also named drud/nginx-proxy, but has been renamed to drud/docker.ddev-router
+
 ## Usage
 
 This container is used to allow all `ddev` sites to exist side by side on a shared port (typically 80). It serves as a proxy to those sites, and forwards traffic to the appropriate dev site depending on the hostname used.


### PR DESCRIPTION
## The Problem:

Just a bit of internal references to nginx-proxy

## The Fix:

Change them to ddev-router.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

OP is https://github.com/drud/ddev/issues/288 (changing all nginx-proxy to ddev-router)
Related ddev PR is https://github.com/drud/ddev/pull/301

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

