### PR TITLE
Stop getting alternate key for apt-get

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM UPSTREAM_REPO
+FROM jwilder/nginx-proxy:0.4.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -6,8 +6,7 @@ RUN { \
       echo 'client_max_body_size 100m;'; \
     } > /etc/nginx/conf.d/ddev.conf
 
-RUN 	apt-key adv --keyserver pgp.mit.edu --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 >/dev/null 2>&1 && \
-      apt-get -qq update && \
+RUN   apt-get -qq update && \
       apt-get -qq install --no-install-recommends --no-install-suggests -y vim less telnet curl && \
       apt-get autoremove -y && \
       apt-get clean -y && \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 DOCKER_REPO ?= drud/ddev-router
 
 # Upstream repo used in the Dockerfile
-UPSTREAM_REPO ?= jwilder/nginx-proxy:0.4.0
+# UPSTREAM_REPO ?=
 
 # Top-level directories to build
 #SRC_DIRS := files drudapi secrets utils


### PR DESCRIPTION
## The Problem:

We were forced to get an updated key before doing apt-get update, but that problem seems to have been resolved upstream. 

*Getting* the key was fragile, commonly causing build failures.

Remove the key get action.

Issue: https://github.com/drud/ddev/issues/471

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

