### PR TITLE
Fix problem with header too big causing router to drop

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -267,6 +267,9 @@ server {
                 include fastcgi.conf;
                 fastcgi_pass {{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ else }}
+                proxy_buffer_size   128k;
+                proxy_buffers   4 256k;
+                proxy_busy_buffers_size   256k;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;
@@ -361,6 +364,9 @@ server {
                 include fastcgi.conf;
                 fastcgi_pass {{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ else }}
+                proxy_buffer_size   128k;
+                proxy_buffers   4 256k;
+                proxy_busy_buffers_size   256k;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;


### PR DESCRIPTION
## The Problem:

@ultimike pointed out a site where nginx was continually reporting that the client was resetting the connection, the `ddev logs` result was just `*53 writev() failed (104: Connection reset by peer) while sending to client, client: 172.18.0.5, server: _, request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "xxx.ddev.local"`

ddev-router's logs were saying `upstream sent too big header while reading response header from upstream`.  (I used `docker logs -f` to see what was going on there)

Thanks to https://stackoverflow.com/a/27551259/215713 for the actual fix.

## The Fix:

Increase proxy buffers

## Manual Test:

This is pushed as drud/ddev-router:20180508_fix_header_too_big

Run the test site against it. This will be hard for most but is easy for @ultimike and for me.

I recommend testing with the paired ddev PR, since we don't have a good way to specify the router image otherwise.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

